### PR TITLE
create a subkernel registration system

### DIFF
--- a/pick_kernel/exceptions.py
+++ b/pick_kernel/exceptions.py
@@ -1,0 +1,2 @@
+class PickRegistrationException(Exception):
+    """Raised when there is an issue registering a kernel"""

--- a/pick_kernel/kernel.py
+++ b/pick_kernel/kernel.py
@@ -18,7 +18,7 @@ from ipykernel.kernelapp import IPKernelApp
 from IPython.core.formatters import DisplayFormatter
 from IPython.display import Markdown
 
-from .subkernel import pick_subkernels
+from .subkernel import _subkernels
 
 # Install the zmq event loop
 ioloop.install()
@@ -127,7 +127,7 @@ Read more about it at https://github.com/nteract/pick
         base, ext = os.path.splitext(self.parent.connection_file)
         connection_file = "{base}-child{ext}".format(base=base, ext=ext,)
 
-        subkernel = pick_subkernels.get_subkernel(name)
+        subkernel = _subkernels.get_subkernel(name)
 
         try:
             km = await subkernel.launch(

--- a/pick_kernel/kernel.py
+++ b/pick_kernel/kernel.py
@@ -13,13 +13,12 @@ from zmq.eventloop import ioloop
 # Rely on Socket subclass that returns Futures for recv*
 from zmq.eventloop.future import Context
 
-from ipykernel.jsonutil import json_clean
 from ipykernel.kernelbase import Kernel
 from ipykernel.kernelapp import IPKernelApp
-from jupyter_client import AsyncKernelManager
-from jupyter_client.session import extract_header
 from IPython.core.formatters import DisplayFormatter
 from IPython.display import Markdown
+
+from .subkernel import pick_subkernels
 
 # Install the zmq event loop
 ioloop.install()
@@ -81,6 +80,9 @@ Read more about it at https://github.com/nteract/pick
         "file_extension": ".py",
     }
 
+    default_kernel = None
+    default_config = None
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Ensure the kernel we work with uses Futures on recv, so we can await them
@@ -120,44 +122,22 @@ Read more about it at https://github.com/nteract/pick
             # Send the message up to the consumer (for example, the notebook)
             self.iopub_socket.send_multipart(msg)
 
-    async def start_kernel(self, config=None):
+    async def start_kernel(self, name=None, config=None):
         # Create a connection file that is named as a child of this kernel
         base, ext = os.path.splitext(self.parent.connection_file)
-        cf = "{base}-child{ext}".format(base=base, ext=ext,)
+        connection_file = "{base}-child{ext}".format(base=base, ext=ext,)
 
-        # TODO: pass config into kernel launch
-        km = AsyncKernelManager(
-            kernel_name="python3",
-            # Pass our IPython session as the session for the KernelManager
-            session=self.session,
-            # Use the same ZeroMQ context that allows for awaiting on recv
-            context=self.future_context,
-            connection_file=cf,
-            # TODO: Figure out if this can be relied on
-            # extra_arguments=["-c", "x = 89898977"],
-            # extra_env={},
-        )
+        subkernel = pick_subkernels.get_subkernel(name)
 
-        # Due to how kernel_cmd is no longer in vogue, we have to set
-        # this extra field that just plain has to be set
-        km.extra_env = {}
-
-        if config is None:
-            config = ""
-
-        km.kernel_cmd = [
-            "python3",
-            "-m",
-            "ipykernel_launcher",
-            "-f",
-            "{connection_file}",
-            "-c",
-            f"""the_config = '''{config}''';""",
-        ]
-        self.log.info("launching child kernel with")
-        self.log.info(km.kernel_cmd)
-
-        await km.start_kernel()
+        try:
+            km = await subkernel.launch(
+                config=config,
+                session=self.session,
+                context=self.future_context,
+                connection_file=connection_file,
+            )
+        except Exception as err:
+            self.log.error(err)
 
         kernel = KernelProxy(manager=km, shell_upstream=self.shell_stream)
         self.iosub.connect(kernel.iopub_url)
@@ -193,8 +173,8 @@ Read more about it at https://github.com/nteract/pick
 
             if not await kc.is_alive():
                 # TODO: Emit child kernel death message into the notebook output
-                raise RuntimeError("Kernel died before replying to kernel_info")
                 self.log.error("Kernel died while launching")
+                raise RuntimeError("Kernel died before replying to kernel_info")
 
             # Wait before sending another kernel info request
             await asyncio.sleep(0.1)
@@ -262,7 +242,7 @@ Read more about it at https://github.com/nteract/pick
             content = parent["content"]
             code = content["code"]
 
-            config = self.parse_cell(content["code"])
+            config, kernel_name = self.parse_cell(content["code"])
             has_config = bool(config)
 
             if has_config:
@@ -275,9 +255,9 @@ Read more about it at https://github.com/nteract/pick
             if has_config and self.child_kernel is not None:
                 self.display(
                     Markdown(
-                        """## Kernel already configured and launched.
+                        f"""## Kernel already configured and launched.
 
-You can only run the `%%kernel.config` cell at the top of your notebook and the
+You can only run the `%%kernel.{kernel_name}` cell at the top of your notebook and the
 start of your session. Please **restart your kernel** and run the cell again if
 you want to change configuration.
 """
@@ -323,7 +303,7 @@ you want to change configuration.
                     display_id=kernel_display_id,
                     parent=parent,
                 )
-                self.child_kernel = await self.start_kernel(config)
+                self.child_kernel = await self.start_kernel(kernel_name, config)
 
                 self.display(
                     Markdown("Runtime ready!"),
@@ -368,7 +348,9 @@ you want to change configuration.
                     parent=parent,
                     display_id=kernel_display_id,
                 )
-                self.child_kernel = await self.start_kernel()
+                self.child_kernel = await self.start_kernel(
+                    self.default_kernel, self.default_config
+                )
                 self.display(
                     # Wipe out the previous message.
                     # NOTE: The Jupyter notebook frontend ignores the case of an empty output for
@@ -383,15 +365,18 @@ you want to change configuration.
 
     def parse_cell(self, cell):
         if not cell.startswith("%%kernel."):
-            return None
+            return None, None
 
         try:
             # Split off our config from the kernel magic name
-            _, raw_config = cell.split("\n", 1)
+            magic_name, raw_config = cell.split("\n", 1)
 
-            return raw_config
-        except Exception:
-            return None
+            kernel_name = magic_name.split("%%kernel.")[1]
+
+            return raw_config, kernel_name
+        except Exception as err:
+            self.log.error(err)
+            return None, None
 
     def _log_task_exceptions(self, task):
         try:

--- a/pick_kernel/subkernel.py
+++ b/pick_kernel/subkernel.py
@@ -30,6 +30,8 @@ class Subkernel(object):
 
     @staticmethod
     async def launch(config, session, context, connection_file):
+        """This must return an AsyncKernelManager() that has
+        already had start_kernel called on it"""
         raise NotImplementedError("launch must be implemented")
 
 

--- a/pick_kernel/subkernel.py
+++ b/pick_kernel/subkernel.py
@@ -1,0 +1,62 @@
+from .exceptions import PickRegistrationException
+
+from jupyter_client import AsyncKernelManager
+
+
+class PickSubKernels(object):
+    def __init__(self):
+        self._subkernels = {}
+
+    def register(self, name, subkernel):
+        self._subkernels[name] = subkernel
+
+    def get_subkernel(self, name=None):
+        """Retrieves an engine by name."""
+        subkernel = self._subkernels.get(name)
+        if not subkernel:
+            raise PickRegistrationException(f"No subkernel named {name} found")
+        return subkernel
+
+    def launch_subkernel(self, name=None):
+        return self.get_subkernel(name).launch()
+
+
+class Subkernel(object):
+    """
+    Base class for subkernels.
+
+    Other specific subkernels should inherit and implement the `launch` method.
+    """
+
+    @staticmethod
+    async def launch(config, session, context, connection_file):
+        raise NotImplementedError("launch must be implemented")
+
+
+class DefaultKernel(Subkernel):
+    @staticmethod
+    async def launch(config, session, context, connection_file):
+        args = []
+        if config:
+            # configuration passed to the default kernel passes options to ipykernel
+            args = list(filter(lambda x: x != "", config.split("\n")))
+
+        km = AsyncKernelManager(
+            kernel_name="python3",
+            # Pass our IPython session as the session for the KernelManager
+            session=session,
+            # Use the same ZeroMQ context that allows for awaiting on recv
+            context=context,
+            connection_file=connection_file,
+        )
+
+        # Tack on additional arguments to the underlying kernel
+        await km.start_kernel(extra_arguments=args)
+
+        return km
+
+
+# Instantiate a PickSubKernels instance, register Handlers
+pick_subkernels = PickSubKernels()
+pick_subkernels.register(None, DefaultKernel)
+pick_subkernels.register("ipykernel", DefaultKernel)

--- a/pick_kernel/subkernel.py
+++ b/pick_kernel/subkernel.py
@@ -3,7 +3,7 @@ from .exceptions import PickRegistrationException
 from jupyter_client import AsyncKernelManager
 
 
-class PickSubKernels(object):
+class SubKernels(object):
     def __init__(self):
         self._subkernels = {}
 
@@ -58,7 +58,10 @@ class DefaultKernel(Subkernel):
         return km
 
 
-# Instantiate a PickSubKernels instance, register Handlers
-pick_subkernels = PickSubKernels()
-pick_subkernels.register(None, DefaultKernel)
-pick_subkernels.register("ipykernel", DefaultKernel)
+# Instantiate a SubKernels instance, register Handlers
+_subkernels = SubKernels()
+_subkernels.register(None, DefaultKernel)
+_subkernels.register("ipykernel", DefaultKernel)
+
+# Expose registration at a top level
+register = _subkernels.register


### PR DESCRIPTION
Closes #4.

This creates a basic registration system that allows setting up new subkernels. The current API is roughly this:

```python
from pick_kernel.subkernel import Subkernel, pick_subkernels

class MyKernel(Subkernel):
    async def launch(config, session, context, connection_file):
        return kernel_manager_that_has_already_started_a_kernel

pick_subkernels.register("wowsers", MyKernel)
```

Which would then be usable as:

```python
%%kernel.wowsers

config: totally
```