### PR TITLE
setup integration tests between papermill & pick

### DIFF
--- a/integration-tests/basic-execution.ipynb
+++ b/integration-tests/basic-execution.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%kernel.ipykernel\n",
+    "\n",
+    "-c\n",
+    "\"import binascii; data = binascii.hexlify(b'Did it work?')\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if(binascii.unhexlify(data) != b'Did it work?'):\n",
+    "    raise Exception(\"Kernel received the wrong data\")\n",
+    "else:\n",
+    "    print(\"All set!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display('hello')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (Picky)",
+   "language": "python",
+   "name": "picky-python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+papermill
 pytest
 pytest-asyncio
 tox


### PR DESCRIPTION
This kicks off #24, to do integration testing between the pick kernel and papermill.

Right now though, on my machine papermill is producing notebooks with no outputs (and no errors...). I'm putting this PR out to allow others to take a look and see what might be going wrong. Assuming you've cloned this branch, you can run these to get the pick kernel started and run the notebook included against papermill:

```
pip3 install -e .[dev]
pick-install
papermill integration-tests/basic-execution.ipynb output--basic-execution.ipynb
```