### PR TITLE
accept third party subkernels via entrypoints

### DIFF
--- a/pick_kernel/subkernels.py
+++ b/pick_kernel/subkernels.py
@@ -2,6 +2,8 @@ from .exceptions import PickRegistrationException
 
 from jupyter_client import AsyncKernelManager
 
+import entrypoints
+
 
 class Subkernels(object):
     def __init__(self):
@@ -9,6 +11,13 @@ class Subkernels(object):
 
     def register(self, name, subkernel):
         self._subkernels[name] = subkernel
+
+    def register_entry_points(self):
+        """Register entrypoints for a subkernel
+        Load handlers provided by other packages
+        """
+        for entrypoint in entrypoints.get_group_all("pick_kernel.subkernel"):
+            self.register(entrypoint.name, entrypoint.load())
 
     def get_subkernel(self, name=None):
         """Retrieves an engine by name."""
@@ -65,10 +74,11 @@ class DefaultKernel(Subkernel):
         return km
 
 
-# Instantiate a SubKernels instance, register Handlers
+# Instantiate a SubKernels instance, register Handlers and entrypoints
 _subkernels = Subkernels()
 _subkernels.register(None, DefaultKernel)
 _subkernels.register("ipykernel", DefaultKernel)
+_subkernels.register_entry_points()
 
 # Expose registration at a top level
 register = _subkernels.register

--- a/pick_kernel/tests/test_subkernel.py
+++ b/pick_kernel/tests/test_subkernel.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from mock import Mock
+from mock import Mock, patch
 
 from .. import subkernels
 from .. import exceptions
@@ -30,3 +30,18 @@ class TestSubkernelRegistration(unittest.TestCase):
             self.subkernels.get_subkernel,
             "non-existent",
         )
+
+    def test_registering_entry_points(self):
+        fake_entrypoint = Mock(load=Mock())
+        fake_entrypoint.name = "fake-subkernel"
+
+        with patch(
+            "entrypoints.get_group_all", return_value=[fake_entrypoint]
+        ) as mock_get_group_all:
+
+            self.subkernels.register_entry_points()
+            mock_get_group_all.assert_called_once_with("pick_kernel.subkernel")
+            self.assertEqual(
+                self.subkernels.get_subkernel("fake-subkernel"),
+                fake_entrypoint.load.return_value,
+            )


### PR DESCRIPTION
This works _exactly_ the same as papermill engines and io.

Let's use the conda kernel created in #18 as an example:

```python
# Package name: pick_conda
# This file: pick_conda/subkernel.py

import os
import sys
from shlex import quote
from jupyter_client import AsyncKernelManager

class AsyncCondaKernelManager(AsyncKernelManager):
    def __init__(self, *args, conda_root=None, conda_environment=None, **kwargs):
        super(AsyncCondaKernelManager, self).__init__(*args, **kwargs)

        self.conda_root = conda_root
        self.conda_environment = conda_environment

    def format_kernel_cmd(self, extra_arguments=None):
        raw_command = ["python", "-m", "ipykernel_launcher", "-f", self.connection_file]
        command = " ".join(quote(c) for c in raw_command)

        activate = os.path.join(self.conda_root, "bin", "activate")

        script = ". '{}' '{}' && exec {}".format(
            activate, self.conda_environment, command
        )

        kernel_cmd = ["bash", "-c", script]

        return kernel_cmd


class CondaKernel(object):
    @staticmethod
    async def launch(config, session, context, connection_file):
        conda_env = config.split("\n")[0]

        km = AsyncCondaKernelManager(
            # TODO: make this configurable or just detect it...
            conda_root=os.environ["CONDA_PREFIIX"],
            conda_environment=conda_env,
            kernel_name="python3",
            # Pass our IPython session as the session for the KernelManager
            session=session,
            # Use the same ZeroMQ context that allows for awaiting on recv
            context=context,
            connection_file=connection_file,
        )

        await km.start_kernel()

        return km
```

Within their setup.py they then register it for `pick_kernel` to pick up:

```python
entry_points={"pick_kernel.subkernel": [
  "conda=pick_conda.subkernel:CondaKernel"
]}
```

Then the user can run this magic:

```
%%kernel.conda
```
