### PR TITLE
allow hiding registered subkernels from listing

### DIFF
--- a/pick_kernel/subkernels.py
+++ b/pick_kernel/subkernels.py
@@ -31,6 +31,7 @@ class Subkernels(object):
         return [
             f"%%kernel.{name}"
             for name in filter(lambda x: x is not None, self._subkernels.keys())
+            if not getattr(self._subkernels[name], "hidden", False)
         ]
 
     def launch_subkernel(self, name=None):
@@ -52,6 +53,8 @@ class Subkernel(object):
 
 
 class DefaultKernel(Subkernel):
+    hidden = True
+
     @staticmethod
     async def launch(config, session, context, connection_file):
         args = []

--- a/pick_kernel/tests/test_subkernel.py
+++ b/pick_kernel/tests/test_subkernel.py
@@ -45,3 +45,19 @@ class TestSubkernelRegistration(unittest.TestCase):
                 self.subkernels.get_subkernel("fake-subkernel"),
                 fake_entrypoint.load.return_value,
             )
+
+    def test_listing(self):
+        mock_subkernel = Mock(spec=["hidden"])
+
+        mock_subkernel.hidden = False
+        self.subkernels.register("mock_subkernel", mock_subkernel)
+        retrieved_subkernel = self.subkernels.get_subkernel("mock_subkernel")
+        self.assertIs(mock_subkernel, retrieved_subkernel)
+
+        hidden_mock_subkernel = Mock(spec=["hidden"])
+        hidden_mock_subkernel.hidden = True
+        self.subkernels.register("hidden_mock_subkernel", hidden_mock_subkernel)
+        retrieved_subkernel = self.subkernels.get_subkernel("hidden_mock_subkernel")
+        self.assertIs(hidden_mock_subkernel, retrieved_subkernel)
+
+        self.assertEqual(self.subkernels.list_subkernels(), ["%%kernel.mock_subkernel"])


### PR DESCRIPTION
This allows for registering kernels that will be hidden from the `list_subkernels` call, primarily for the help messages. The intended use is for operators of a Jupyter deployment to register experimental subkernels that users don't see in help messages.